### PR TITLE
check that the AMI matches what the launch configuration specifies

### DIFF
--- a/lib/hashicorptools/auto_scaling_group.rb
+++ b/lib/hashicorptools/auto_scaling_group.rb
@@ -89,6 +89,14 @@ module Hashicorptools
       end
     end
 
+    def verify_all_instances_using_correct_ami
+      launch_configuration = Aws::AutoScaling::LaunchConfiguration.new(name: group.launch_configuration_name, client: autoscaling)
+      image_id = launch_configuration.image_id
+      group.instances.each do |i|
+        raise "#{i.instance_id} has the incorrect AMI, not #{image_id} from current LaunchConfig" if i.image_id != image_id
+      end
+    end
+
     private
 
     def wait_for_activities_to_complete(group)

--- a/lib/hashicorptools/update_launch_configuration.rb
+++ b/lib/hashicorptools/update_launch_configuration.rb
@@ -16,6 +16,8 @@ module Hashicorptools
 
         # then bring the instance count back down again.
         asg.set_desired_instances(current_count)
+
+        asg.verify_all_instances_using_correct_ami
       end
     end
   end


### PR DESCRIPTION
When scaling up and then down again, a launch failure would mean that the scale up/down would succeed successfully but the AMI might not be correct on all instances. This change raises if any AMI is incorrect. 

This has been somewhat quickly tested in a ruby console but I'm not sure how to generate the failure scenario so not sure how to really test it beyond using it in practice. 