### PR TITLE
Replace AWS SDK v1 uses with v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source "http://rubygems.org"
 
-# try to slowly migrate to v2 of the aws api
 gem 'aws-sdk', '~> 2'
-
-# this is somewhat undesirable but lets us update json gem version. We should really replace the old v1 code.
-gem 'aws-sdk-v1-ruby24', git: 'https://github.com/seielit/aws-sdk-v1-ruby24.git', branch: 'aws-sdk-v1-ruby24'
 gem 'dotenv', '~> 2.2', '>= 2.2.1'
 gem 'thor', '>= 0.20.0'
 gem 'activesupport', '>= 5.1.4'

--- a/hashicorptools.gemspec
+++ b/hashicorptools.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Nathan Woodhull".freeze]
-  s.date = "2020-07-29"
+  s.date = "2020-07-30"
   s.description = "Wrappers for terraform and packer".freeze
   s.email = "systems@controlshiftlabs.com".freeze
   s.executables = ["ec2_host".freeze]
@@ -39,47 +39,32 @@ Gem::Specification.new do |s|
     "lib/hashicorptools/packer.rb",
     "lib/hashicorptools/update_launch_configuration.rb",
     "lib/hashicorptools/variables.rb",
-    "spec/hashicorptools_spec.rb",
+    "spec/ec2_utilities_spec.rb",
     "spec/spec_helper.rb"
   ]
   s.homepage = "http://github.com/woodhull/hashicorptools".freeze
   s.licenses = ["MIT".freeze]
-  s.rubygems_version = "3.0.8".freeze
+  s.rubygems_version = "3.1.2".freeze
   s.summary = "Wrappers for terraform and packer".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
+  end
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<aws-sdk>.freeze, ["~> 2"])
-      s.add_runtime_dependency(%q<aws-sdk-v1-ruby24>.freeze, [">= 0"])
-      s.add_runtime_dependency(%q<dotenv>.freeze, ["~> 2.2", ">= 2.2.1"])
-      s.add_runtime_dependency(%q<thor>.freeze, [">= 0.20.0"])
-      s.add_runtime_dependency(%q<activesupport>.freeze, [">= 5.1.4"])
-      s.add_runtime_dependency(%q<byebug>.freeze, [">= 10.0.2"])
-      s.add_runtime_dependency(%q<git>.freeze, ["> 1.3"])
-      s.add_development_dependency(%q<rspec>.freeze, ["> 3.7"])
-      s.add_development_dependency(%q<rdoc>.freeze, ["> 3.12"])
-      s.add_development_dependency(%q<bundler>.freeze, ["> 2.0"])
-      s.add_development_dependency(%q<juwelier>.freeze, [">= 0"])
-      s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
-    else
-      s.add_dependency(%q<aws-sdk>.freeze, ["~> 2"])
-      s.add_dependency(%q<aws-sdk-v1-ruby24>.freeze, [">= 0"])
-      s.add_dependency(%q<dotenv>.freeze, ["~> 2.2", ">= 2.2.1"])
-      s.add_dependency(%q<thor>.freeze, [">= 0.20.0"])
-      s.add_dependency(%q<activesupport>.freeze, [">= 5.1.4"])
-      s.add_dependency(%q<byebug>.freeze, [">= 10.0.2"])
-      s.add_dependency(%q<git>.freeze, ["> 1.3"])
-      s.add_dependency(%q<rspec>.freeze, ["> 3.7"])
-      s.add_dependency(%q<rdoc>.freeze, ["> 3.12"])
-      s.add_dependency(%q<bundler>.freeze, ["> 2.0"])
-      s.add_dependency(%q<juwelier>.freeze, [">= 0"])
-      s.add_dependency(%q<simplecov>.freeze, [">= 0"])
-    end
+  if s.respond_to? :add_runtime_dependency then
+    s.add_runtime_dependency(%q<aws-sdk>.freeze, ["~> 2"])
+    s.add_runtime_dependency(%q<dotenv>.freeze, ["~> 2.2", ">= 2.2.1"])
+    s.add_runtime_dependency(%q<thor>.freeze, [">= 0.20.0"])
+    s.add_runtime_dependency(%q<activesupport>.freeze, [">= 5.1.4"])
+    s.add_runtime_dependency(%q<byebug>.freeze, [">= 10.0.2"])
+    s.add_runtime_dependency(%q<git>.freeze, ["> 1.3"])
+    s.add_development_dependency(%q<rspec>.freeze, ["> 3.7"])
+    s.add_development_dependency(%q<rdoc>.freeze, ["> 3.12"])
+    s.add_development_dependency(%q<bundler>.freeze, ["> 2.0"])
+    s.add_development_dependency(%q<juwelier>.freeze, [">= 0"])
+    s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
   else
     s.add_dependency(%q<aws-sdk>.freeze, ["~> 2"])
-    s.add_dependency(%q<aws-sdk-v1-ruby24>.freeze, [">= 0"])
     s.add_dependency(%q<dotenv>.freeze, ["~> 2.2", ">= 2.2.1"])
     s.add_dependency(%q<thor>.freeze, [">= 0.20.0"])
     s.add_dependency(%q<activesupport>.freeze, [">= 5.1.4"])

--- a/lib/hashicorptools.rb
+++ b/lib/hashicorptools.rb
@@ -2,7 +2,6 @@ require 'bundler/setup'
 require 'dotenv'
 require 'thor'
 require 'active_support/all'
-require 'aws-sdk-v1'
 require 'aws-sdk'
 
 module Hashicorptools

--- a/lib/hashicorptools/ec2_utilities.rb
+++ b/lib/hashicorptools/ec2_utilities.rb
@@ -5,7 +5,8 @@ module Hashicorptools
     end
 
     def amis(tag = tag_name)
-      sort_by_created_at(  ec2.images.with_owner('self').with_tag('Name', tag).to_a )
+      images = ec2.describe_images({owners: ['self'], filters: [{name: 'tag:Name', values: [tag]}]}).images
+      sort_by_created_at(images)
     end
 
     def ec2
@@ -21,13 +22,11 @@ module Hashicorptools
     end
 
     def vpc_with_name(name)
-      vpcs = ec2.client.describe_vpcs({filters: [{name: 'tag:Name', values: [name]}]}).vpc_set
-      vpcs.first
+      ec2.describe_vpcs({filters: [{name: 'tag:Name', values: [name]}]}).vpcs.first
     end
 
     def internet_gateway_for_vpc(vpc_id)
-      igs = ec2.client.describe_internet_gateways({filters: [{name: 'attachment.vpc-id', values: [vpc_id]}]}).internet_gateway_set
-      igs.first
+      ec2.describe_internet_gateways({filters: [{name: 'attachment.vpc-id', values: [vpc_id]}]}).internet_gateways.first
     end
 
     def sort_by_created_at(collection)

--- a/lib/hashicorptools/ec2_utilities.rb
+++ b/lib/hashicorptools/ec2_utilities.rb
@@ -17,7 +17,7 @@ module Hashicorptools
               'us-east-1'
             end
 
-      @_ec2 = AWS::EC2.new(region: reg)
+      @_ec2 = Aws::EC2::Client.new(region: reg)
     end
 
     def vpc_with_name(name)

--- a/lib/hashicorptools/packer.rb
+++ b/lib/hashicorptools/packer.rb
@@ -137,15 +137,16 @@ module Hashicorptools
       @auto_scaling ||= Aws::AutoScaling::Client.new(region: client_region)
     end
 
-    def ec2_v2(client_region=region)
-      @ec2 ||= Aws::EC2::Client.new(region: client_region)
+    def regional_ec2_client(client_region=region)
+      @_regional_ec2_clients = {} if @_regional_ec2_clients.nil?
+      @_regional_ec2_clients[client_region] ||= Aws::EC2::Client.new(region: client_region)
     end
 
     def amis_in_use(client_region)
       launch_configs = auto_scaling(client_region).describe_launch_configurations
       image_ids = launch_configs.data['launch_configurations'].collect{|lc| lc.image_id}.flatten
 
-      ec2_reservations = ec2_v2(client_region).describe_instances
+      ec2_reservations = regional_ec2_client(client_region).describe_instances
       image_ids << ec2_reservations.reservations.collect{|res| res.instances.collect{|r| r.image_id}}.flatten
       image_ids.flatten
     end

--- a/lib/hashicorptools/packer.rb
+++ b/lib/hashicorptools/packer.rb
@@ -54,9 +54,9 @@ module Hashicorptools
         end
 
         ami_id = match[1]
-        unless ec2.describe_images({image_ids: [ami_id]}).images.any?
-          puts "Removing obsolete snapshot #{snapshot.id} - #{snapshot.description}"
-          ec2.delete_snapshot({snapshot_id: snapshot.id})
+        unless Aws::EC2::Image.new(ami_id, region: region).exists?
+          puts "Removing obsolete snapshot #{snapshot.snapshot_id} - #{snapshot.description}"
+          ec2.delete_snapshot({snapshot_id: snapshot.snapshot_id})
         end
       end
     end

--- a/lib/hashicorptools/packer.rb
+++ b/lib/hashicorptools/packer.rb
@@ -201,8 +201,10 @@ module Hashicorptools
       ec2_client = regional_ec2_client(snapshot_region)
 
       ebs_mappings.each do |ebs_mapping|
-        puts "Deleting snapshot #{ebs_mapping.ebs.snapshot_id}"
-        ec2_client.delete_snapshot({snapshot_id: ebs_mapping.ebs.snapshot_id})
+        unless ebs_mapping.ebs.nil?
+          puts "Deleting snapshot #{ebs_mapping.ebs.snapshot_id}"
+          ec2_client.delete_snapshot({snapshot_id: ebs_mapping.ebs.snapshot_id})
+        end
       end
     end
   end

--- a/spec/ec2_utilities_spec.rb
+++ b/spec/ec2_utilities_spec.rb
@@ -1,0 +1,14 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+describe Hashicorptools::Ec2Utilities, type: :helper do
+  let(:including_class) { Class.new { include Hashicorptools::Ec2Utilities } }
+
+  subject { including_class.new }
+
+  describe '#ec2' do
+    it 'should return a client' do
+      client = subject.ec2
+      expect(client).to be_a Aws::EC2::Client
+    end
+  end
+end

--- a/spec/hashicorptools_spec.rb
+++ b/spec/hashicorptools_spec.rb
@@ -1,8 +1,0 @@
-require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
-
-describe "Hashicorptools" do
-  it "fails" do
-    pending
-    fail "hey buddy, you should probably rename this file and start specing for real"
-  end
-end


### PR DESCRIPTION
This switches the remaining code that was still using the EOLed Version 1 of aws-sdk to use Version 2, so we can upgrade the `json` dependency in codebases that use this gem.

I've checked and it's mostly only our AMI building code, not deployment, that should be affected by these changes. I tested locally with geoip that the AMI stuff seems to be working.

Once this is merged, I'll cut a new major version release of this gem, and update all the places we use it.