### PR TITLE
Upgrade to modular v3 AWS SDK gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source "http://rubygems.org"
 
-gem 'aws-sdk', '~> 2'
+gem 'aws-sdk-autoscaling', '~> 1'
+gem 'aws-sdk-codedeploy', '~> 1'
+gem 'aws-sdk-ec2', '~> 1'
+gem 'aws-sdk-elasticloadbalancing', '~> 1'
+
 gem 'dotenv', '~> 2.2', '>= 2.2.1'
 gem 'thor', '>= 0.20.0'
 gem 'activesupport', '>= 5.1.4'

--- a/hashicorptools.gemspec
+++ b/hashicorptools.gemspec
@@ -52,7 +52,10 @@ Gem::Specification.new do |s|
   end
 
   if s.respond_to? :add_runtime_dependency then
-    s.add_runtime_dependency(%q<aws-sdk>.freeze, ["~> 2"])
+    s.add_runtime_dependency(%q<aws-sdk-autoscaling>.freeze, ["~> 1"])
+    s.add_runtime_dependency(%q<aws-sdk-codedeploy>.freeze, ["~> 1"])
+    s.add_runtime_dependency(%q<aws-sdk-ec2>.freeze, ["~> 1"])
+    s.add_runtime_dependency(%q<aws-sdk-elasticloadbalancing>.freeze, ["~> 1"])
     s.add_runtime_dependency(%q<dotenv>.freeze, ["~> 2.2", ">= 2.2.1"])
     s.add_runtime_dependency(%q<thor>.freeze, [">= 0.20.0"])
     s.add_runtime_dependency(%q<activesupport>.freeze, [">= 5.1.4"])
@@ -64,7 +67,10 @@ Gem::Specification.new do |s|
     s.add_development_dependency(%q<juwelier>.freeze, [">= 0"])
     s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
   else
-    s.add_dependency(%q<aws-sdk>.freeze, ["~> 2"])
+    s.add_dependency(%q<aws-sdk-autoscaling>.freeze, ["~> 1"])
+    s.add_dependency(%q<aws-sdk-codedeploy>.freeze, ["~> 1"])
+    s.add_dependency(%q<aws-sdk-ec2>.freeze, ["~> 1"])
+    s.add_dependency(%q<aws-sdk-elasticloadbalancing>.freeze, ["~> 1"])
     s.add_dependency(%q<dotenv>.freeze, ["~> 2.2", ">= 2.2.1"])
     s.add_dependency(%q<thor>.freeze, [">= 0.20.0"])
     s.add_dependency(%q<activesupport>.freeze, [">= 5.1.4"])

--- a/lib/hashicorptools.rb
+++ b/lib/hashicorptools.rb
@@ -2,7 +2,6 @@ require 'bundler/setup'
 require 'dotenv'
 require 'thor'
 require 'active_support/all'
-require 'aws-sdk'
 
 module Hashicorptools
 end

--- a/lib/hashicorptools/auto_scaling_group.rb
+++ b/lib/hashicorptools/auto_scaling_group.rb
@@ -1,4 +1,7 @@
 require "timeout"
+require 'aws-sdk-autoscaling'
+require 'aws-sdk-ec2'
+require 'aws-sdk-elasticloadbalancing'
 
 module Hashicorptools
   class AutoScalingGroup

--- a/lib/hashicorptools/code_deploy.rb
+++ b/lib/hashicorptools/code_deploy.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'aws-sdk'
+require 'aws-sdk-codedeploy'
 require 'dotenv'
 require 'git'
 require 'logger'

--- a/lib/hashicorptools/ec2_utilities.rb
+++ b/lib/hashicorptools/ec2_utilities.rb
@@ -1,3 +1,5 @@
+require 'aws-sdk-ec2'
+
 module Hashicorptools
   module Ec2Utilities
     def current_ami(tag = tag_name)

--- a/lib/hashicorptools/host.rb
+++ b/lib/hashicorptools/host.rb
@@ -1,3 +1,5 @@
+require 'aws-sdk-ec2'
+
 module Hashicorptools
   class Host < Thor
     

--- a/lib/hashicorptools/packer.rb
+++ b/lib/hashicorptools/packer.rb
@@ -1,3 +1,6 @@
+require 'aws-sdk-autoscaling'
+require 'aws-sdk-ec2'
+
 module Hashicorptools
   NUMBER_OF_AMIS_TO_KEEP = 2
 


### PR DESCRIPTION
This switches from the monolithic AWS SDK v2 gem to the modular AWS SDK v3 gems, in accordance with [the upgrade guide](https://github.com/aws/aws-sdk-ruby#upgrading-guide). The functionality should be the same, so we don't need to change how we use the libraries.