### PR TITLE
CodeDeploy helper: exit with appropriate status code

### DIFF
--- a/lib/hashicorptools/code_deploy.rb
+++ b/lib/hashicorptools/code_deploy.rb
@@ -90,9 +90,10 @@ module Hashicorptools
             # thread.value waits for the thread to finish with #join, then returns the value of the expression
             thread_succeeded = thread.value
             all_succeeded = all_succeeded && thread_succeeded
-          rescue Exception => e
+          rescue StandardError => e
             # Don't quit whole program on exception in thread, just print exception and exit thread
             puts "[#{aws_regions[index]}] EXCEPTION: #{e}"
+            all_succeeded = false
           end
         end
       end

--- a/lib/hashicorptools/code_deploy.rb
+++ b/lib/hashicorptools/code_deploy.rb
@@ -72,9 +72,11 @@ module Hashicorptools
 
       puts "Deploying for regions: #{aws_regions}"
 
-      threads = []
+      all_succeeded = true
       aws_regions.each_slice(2) do |aws_regions_batch|
         puts "Deploying for batch of regions: #{aws_regions_batch}"
+
+        threads = []
         aws_regions_batch.each do |aws_region|
           thread = Thread.new{ region_deployment(aws_region).create_deployment(commit.sha, commit.message) }
           threads.push(thread)
@@ -82,13 +84,18 @@ module Hashicorptools
 
         threads.each_with_index do |thread, index|
           begin
-            thread.join
+            # thread.value waits for the thread to finish with #join, then returns the value of the expression
+            thread_succeeded = thread.value
+            all_succeeded = all_succeeded && thread_succeeded
           rescue Exception => e
             # Don't quit whole program on exception in thread, just print exception and exit thread
             puts "[#{aws_regions[index]}] EXCEPTION: #{e}"
           end
         end
       end
+
+      # Return a success or failure status code to be consumed by bash
+      exit(all_succeeded)
     end
 
     private

--- a/lib/hashicorptools/code_deploy.rb
+++ b/lib/hashicorptools/code_deploy.rb
@@ -31,6 +31,9 @@ module Hashicorptools
                                           })
       output "created deployment #{response.deployment_id}"
       output "https://console.aws.amazon.com/codedeploy/home?region=#{aws_region}#/deployments/#{response.deployment_id}"
+
+      # Classes that override this method should return true for a successful deployment, false otherwise
+      return true
     end
 
     private


### PR DESCRIPTION
This updates the CodeDeploy helper class so that if any of the region deployments fail, it will exit with a non-zero status code. This will allow bash scripts that invoke this deployment helper to act appropriately in the event of a failed deployment.

Also included:
- Avoids [rescuing Exception](https://thoughtbot.com/blog/rescue-standarderror-not-exception); best practice is to rescue StandardError instead
- Changes where we initialize the list of threads, to avoid weirdness if we end up running a deployment to three or more regions. (With only 1-2 regions, this has never come up.)